### PR TITLE
Color contrast fix

### DIFF
--- a/css/pnp-landing-page.css
+++ b/css/pnp-landing-page.css
@@ -3243,7 +3243,7 @@ a {
   margin-right: 0px;
   margin-bottom: 16px;
   margin-left: 0px;
-  color: #0078d4;
+  color: #0067B8;
   font-size: 14px;
   line-height: 25px;
   font-weight: 600;

--- a/parkersplace/assets/css/pnp-landing-page.css
+++ b/parkersplace/assets/css/pnp-landing-page.css
@@ -3243,7 +3243,7 @@ a {
   margin-right: 0px;
   margin-bottom: 16px;
   margin-left: 0px;
-  color: #0078d4;
+  color: #0067B8;
   font-size: 14px;
   line-height: 25px;
   font-weight: 600;

--- a/parkersplace/assets/css/pnp-parkersplace-page.css
+++ b/parkersplace/assets/css/pnp-parkersplace-page.css
@@ -3252,7 +3252,7 @@ a {
   margin-right: 0px;
   margin-bottom: 16px;
   margin-left: 0px;
-  color: #0078d4;
+  color: #0067B8;
   font-size: 14px;
   line-height: 25px;
   font-weight: 600;


### PR DESCRIPTION
Changed lnd_title to official MSFT branding color #0067B8 which ensures correct color contrast between background/foreground. This fixes compliance error found in FastPass. See https://mwf.azurewebsites.net/catalog/utilities-color/