### PR TITLE
Change current nav link to yellow

### DIFF
--- a/css/pnp-landing-page.css
+++ b/css/pnp-landing-page.css
@@ -5777,7 +5777,7 @@ a {
 }
 
 .nav03_link.w--current {
-  color: hsla(0, 0%, 100%, 0.5);
+  color: #FEF000;
 }
 
 .navigation-block {

--- a/parkersplace/assets/css/pnp-landing-page.css
+++ b/parkersplace/assets/css/pnp-landing-page.css
@@ -5844,7 +5844,7 @@ a {
 }
 
 .nav03_link.w--current {
-  color: hsla(0, 0%, 100%, 0.5);
+  color: #FEF000;
 }
 
 .navigation-block {

--- a/parkersplace/assets/css/pnp-parkersplace-page.css
+++ b/parkersplace/assets/css/pnp-parkersplace-page.css
@@ -5888,7 +5888,7 @@ a {
 }
 
 .nav03_link.w--current {
-  color: hsla(0, 0%, 100%, 0.5);
+  color: #FEF000;
 }
 
 .navigation-block {


### PR DESCRIPTION
The hsla opacity on the current nav link does not provide enough contrast for low vision or high contrast dark mode. Changed CSS from hsla() to accessibile yellow #FEF000