### PR TITLE
Updates the page to add new extension section. Closes: #31

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,6 +817,8 @@
       </div>
     </div>
   </div>
+  <!-- END: SDKs -->
+  <!-- BEGIN: Tools -->
   <div id="tools" class="wrapper-2 m80-80">
     <div class="section">
       <div class="w-layout-grid product5-grid">
@@ -852,36 +854,6 @@
                   <div class="fdml button-arrow-2"></div>
                 </a>
               </div><a href="https://www.powershellgallery.com/packages/Microsoft.Graph"
-                class="lnd_card_link w-inline-block"></a>
-            </div>
-          </div>
-
-          <div id="vscode-viva">
-            <div class="lnd_card_template _38">
-              <div class="lnd_card_text_wrap">
-                <h6 class="lnd_h6">TOOLS</h6>
-                <h6 class="lnd_card_title">Viva Connections Toolkit for Visual Studio Code</h6>
-                <a href="https://marketplace.visualstudio.com/items?itemName=m365pnp.viva-connections-toolkit"
-                  class="button-wrapper w-inline-block">
-                  <div class="button-text">LEARN MORE</div>
-                  <div class="fdml button-arrow-2"></div>
-                </a>
-              </div><a href="https://marketplace.visualstudio.com/items?itemName=m365pnp.viva-connections-toolkit"
-                class="lnd_card_link w-inline-block"></a>
-            </div>
-          </div>
-
-          <div id="vscode-teams">
-            <div class="lnd_card_template _25">
-              <div class="lnd_card_text_wrap">
-                <h6 class="lnd_h6">DEVELOPMENT TOOLS</h6>
-                <h6 class="lnd_card_title">Microsoft Teams Toolkit</h6>
-                <a href="https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension"
-                  class="button-wrapper w-inline-block">
-                  <div class="button-text">LEARN MORE</div>
-                  <div class="fdml button-arrow-2"></div>
-                </a>
-              </div><a href="https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension"
                 class="lnd_card_link w-inline-block"></a>
             </div>
           </div>
@@ -930,6 +902,53 @@
             </div>
           </div>
 
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- END: Tools -->
+  <!-- BEGIN: Extensions -->
+  <div id="extensions" class="wrapper-2 m80-80">
+    <div class="section">
+      <div class="w-layout-grid product5-grid">
+        <div id="w-node-47a85e726b0e-2b0d0585" class="home-sections-label">
+          <p data-w-id="48f1f782-beaa-c9ec-1aa1-74013dbaa6a3" class="lnd_title">VISUAL STUDIO AND VISUAL STUDIO CODE EXTENSIONS</p>
+          <div class="lnd_h2">Extensions</div>
+          <p class="lnd_paragraph">Boost your productivity without leaving the context of your work.
+          </p>
+        </div>
+        <div id="w-node-47a85e726b18-2b0d0585" class="w-layout-grid homepage-layouts-grid">
+
+          <div id="vscode-viva">
+            <div class="lnd_card_template _38">
+              <div class="lnd_card_text_wrap">
+                <h6 class="lnd_h6">DEVELOPMENT TOOLS</h6>
+                <h6 class="lnd_card_title">Viva Connections Toolkit</h6>
+                <a href="https://marketplace.visualstudio.com/items?itemName=m365pnp.viva-connections-toolkit"
+                  class="button-wrapper w-inline-block">
+                  <div class="button-text">LEARN MORE</div>
+                  <div class="fdml button-arrow-2"></div>
+                </a>
+              </div><a href="https://marketplace.visualstudio.com/items?itemName=m365pnp.viva-connections-toolkit"
+                class="lnd_card_link w-inline-block"></a>
+            </div>
+          </div>
+
+          <div id="vscode-teams">
+            <div class="lnd_card_template _25">
+              <div class="lnd_card_text_wrap">
+                <h6 class="lnd_h6">DEVELOPMENT TOOLS</h6>
+                <h6 class="lnd_card_title">Microsoft Teams Toolkit</h6>
+                <a href="https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension"
+                  class="button-wrapper w-inline-block">
+                  <div class="button-text">LEARN MORE</div>
+                  <div class="fdml button-arrow-2"></div>
+                </a>
+              </div><a href="https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension"
+                class="lnd_card_link w-inline-block"></a>
+            </div>
+          </div>
+
           <div id="vs-extension">
             <div class="lnd_card_template _03">
               <div class="lnd_card_text_wrap">
@@ -948,6 +967,7 @@
       </div>
     </div>
   </div>
+  <!-- END: Extensions -->
   <!-- BEGIN: Forums -->
   <div id="forums" class="wrapper-2 m80-80 grey">
     <div class="section">


### PR DESCRIPTION
## 🎯 Aim 

The aim of this change is to separate the VS and VS Code extension into a new section. This will bring more clarity to the tooling part and makes more sense than having it like it is currently, so those tools are together with the CLI's tooling.

## 📷 Result

New section on page

![image](https://github.com/pnp/pnp.github.io/assets/58668583/3be2b959-3383-40c0-815a-08d13dd6eb60)

The current tooling section (for CLI tools) now without the extensions

![1](https://github.com/pnp/pnp.github.io/assets/58668583/91eda5b0-55c6-47ef-a93e-54ed9cbec388)

## 🔗 Related

Closes: #31