### PR TITLE
Fixes invite link to Discord server

### DIFF
--- a/content/forums/discord.md
+++ b/content/forums/discord.md
@@ -2,5 +2,5 @@
 title: "Discord"
 description: "Welcome to our vibrant Microsoft 365 & Power Platform Community Discord server, a thriving hub for enthusiasts, professionals, and learners alike."
 image: "images/forums-background-discord.webp"
-externalLink: "https://discord.com/invite/AXZqG5DKND"
+externalLink: "https://discord.com/invite/YtYrav2VGW"
 ---


### PR DESCRIPTION
## 🎯 Aim

It seems that currently Discord Invlie link on our home page does not work
![image](https://github.com/user-attachments/assets/18c7686d-ddd6-44ac-bb76-fdbbda910c64)

I generated a new one: https://discord.com/invite/YtYrav2VGW which will not expire

